### PR TITLE
Set hint on TextInputLayout (#1962)

### DIFF
--- a/input/src/main/java/com/afollestad/materialdialogs/input/DialogInputExt.kt
+++ b/input/src/main/java/com/afollestad/materialdialogs/input/DialogInputExt.kt
@@ -159,7 +159,7 @@ private fun MaterialDialog.styleInput(
   val resources = windowContext.resources
   val editText = getInputField()
 
-  editText.hint = hint ?: if (hintRes != null) resources.getString(hintRes) else null
+  getInputLayout().hint = hint ?: if (hintRes != null) resources.getString(hintRes) else null
   editText.inputType = inputType
   editText.maybeSetTextColor(
       windowContext,


### PR DESCRIPTION
Set hint on TextInputLayout instead of EditText so that it animates properly when you start typing.

From documentation:
* The hint should be set on the TextInputLayout, rather than the EditText. If a hint is specified
 * on the child EditText in XML, the TextInputLayout might still work correctly; TextInputLayout
 * will use the EditText's hint as its floating label. However, future calls to modify the hint will
 * not update TextInputLayout's hint.

### Guidelines 

1. You must run the `spotlessApply` task before commiting, either through Android Studio or with `./gradlew spotlessApply`.
2. A PR should be focused and contained. If you are changing multiple unrelated things, they should be in separate PRs.
3. A PR should fix a bug or solve a problem - something that only you would use is not necessarily something that should be published.
4. Give your PR a detailed title and description - look over your code one last time before actually creating the PR. Give it a self-review.

**If you do not follow the guidelines, your PR will be rejected.**
